### PR TITLE
CMake: fix Windows Speex compilation

### DIFF
--- a/pjmedia/build/CMakeLists.txt
+++ b/pjmedia/build/CMakeLists.txt
@@ -124,6 +124,7 @@ endif()
 if(WITH_CODEC_SPEEX)
   set(PJMEDIA-CODECS_SRC ${PJMEDIA-CODECS_SRC}
     ../src/pjmedia-codec/speex_codec.c)
+  include_directories(AFTER SYSTEM ../../third_party/speex/include)
 endif()
 
 if(WITH_CODEC_ILBC)

--- a/third_party/build/speex/CMakeLists.txt
+++ b/third_party/build/speex/CMakeLists.txt
@@ -45,6 +45,6 @@ set(SPEEX_SRC ${SPEEX_SRC}
 
 include_directories(AFTER SYSTEM  . ../../speex/include/)
 
-add_definitions(-DHAVE_CONFIG_H)
+add_definitions(-DHAVE_CONFIG_H -D_USE_MATH_DEFINES)
 
 add_library(speex OBJECT ${SPEEX_SRC})


### PR DESCRIPTION
Just starting to experiment with PJSIP-CMake on Windows and encountered problems building Speex early on. These additions seemed to get it building on Windows with VS 2013 express.